### PR TITLE
Verify marker in timeline - merge to main

### DIFF
--- a/fcpx_marker_tool/fcpx_marker_tool.py
+++ b/fcpx_marker_tool/fcpx_marker_tool.py
@@ -1,0 +1,5 @@
+def main():
+    print("running fcpx_marker_tool")
+
+if __name__ == "__main__":
+    main()

--- a/fcpx_marker_tool/fcpx_marker_tool.py
+++ b/fcpx_marker_tool/fcpx_marker_tool.py
@@ -1,5 +1,0 @@
-def main():
-    print("running fcpx_marker_tool")
-
-if __name__ == "__main__":
-    main()

--- a/fcpx_marker_tool/main.py
+++ b/fcpx_marker_tool/main.py
@@ -1,0 +1,5 @@
+def main():
+    print("running fcpx_marker_tool")
+
+if __name__ == "__main__":
+    main()

--- a/fcpx_marker_tool_v1.py
+++ b/fcpx_marker_tool_v1.py
@@ -76,8 +76,11 @@ def grab_marker_start_time(clip_offset, clip_start, marker_start, timeline_info,
 
     return chapter_marker_timeline_frame
 
-def marker_timeline_check():
-    print("Checking marker")
+def marker_timeline_check(marker_frame, clip_start_frame, clip_end_frame):
+    if (marker_frame >= clip_start_frame) and (marker_frame <= clip_end_frame):
+        return True
+    else:
+        return False
 
 def frames_to_timecode(frame_count, frame_rate):
 

--- a/fcpx_marker_tool_v1.py
+++ b/fcpx_marker_tool_v1.py
@@ -48,9 +48,10 @@ def grab_clips(xml_root):
 
         clip_offset = clip.get("offset")
         clip_start = clip.get("start")
+        clip_duration = clip.get("duration")
         marker_list = clip.findall("chapter-marker")
 
-        clips_dict[clip_offset, clip_start] = marker_list
+        clips_dict[clip_offset, clip_start, clip_duration] = marker_list
 
     return clips_dict
 
@@ -74,6 +75,9 @@ def grab_marker_start_time(clip_offset, clip_start, marker_start, timeline_info,
     chapter_marker_timeline_frame = int((chapter_start_frames - clip_start_frames) + clip_offset_frames + timeline_starting_frame)
 
     return chapter_marker_timeline_frame
+
+def marker_timeline_check():
+    print("Checking marker")
 
 def frames_to_timecode(frame_count, frame_rate):
 
@@ -107,23 +111,19 @@ def generate_output(clips_dict, timeline_info):
     original_frame_rate = frame_rate_to_tuple(timeline_info["frame_rate"])
     formatted_frame_rate = check_for_ndf(timeline_info, original_frame_rate)
 
-    for clip_offset, clip_start in clips_dict:
-        clip_marker_list = clips_dict[clip_offset, clip_start]
+    for clip_offset, clip_start, clip_duration in clips_dict:
+        clip_marker_list = clips_dict[clip_offset, clip_start, clip_duration]
 
         for marker in clip_marker_list:
             marker_start = marker.get("start")
-            marker_name = marker.get("value")
-            # print(marker_name)
             marker_frame = grab_marker_start_time(clip_offset, clip_start, marker_start, timeline_info, original_frame_rate)
             marker_timecode = frames_to_timecode(marker_frame, formatted_frame_rate)
-            timeline_marker_list.append(str(f'{marker_timecode}, {marker_name}'))
-
-    print(*timeline_marker_list, sep='\n')
+            timeline_marker_list.append(str(marker_timecode))
 
     # sort list and only keep unique values, necessary due FCPX assigning duplicate chapter-markers to asset-clips in .fcpxml files
     timeline_marker_list = sorted(set(timeline_marker_list))
     
-    # print(*timeline_marker_list, sep='\n')
+    print(*timeline_marker_list, sep='\n')
 
 def main():
     xml_file = input("Enter xml file path: ")

--- a/fcpx_marker_tool_v1.py
+++ b/fcpx_marker_tool_v1.py
@@ -112,14 +112,18 @@ def generate_output(clips_dict, timeline_info):
 
         for marker in clip_marker_list:
             marker_start = marker.get("start")
+            marker_name = marker.get("value")
+            # print(marker_name)
             marker_frame = grab_marker_start_time(clip_offset, clip_start, marker_start, timeline_info, original_frame_rate)
             marker_timecode = frames_to_timecode(marker_frame, formatted_frame_rate)
-            timeline_marker_list.append(str(marker_timecode))
+            timeline_marker_list.append(str(f'{marker_timecode}, {marker_name}'))
+
+    print(*timeline_marker_list, sep='\n')
 
     # sort list and only keep unique values, necessary due FCPX assigning duplicate chapter-markers to asset-clips in .fcpxml files
     timeline_marker_list = sorted(set(timeline_marker_list))
     
-    print(*timeline_marker_list, sep='\n')
+    # print(*timeline_marker_list, sep='\n')
 
 def main():
     xml_file = input("Enter xml file path: ")

--- a/fcpx_marker_tool_v1.py
+++ b/fcpx_marker_tool_v1.py
@@ -65,19 +65,21 @@ def get_number_of_frames(rational_time_value, frame_rate):
 
     return number_of_frames
 
-def grab_marker_start_time(clip_offset, clip_start, marker_start, timeline_info, frame_rate):
+def grab_marker_and_clip_frames(clip_offset, clip_start, clip_duration, marker_start, timeline_start, frame_rate):
 
-    timeline_starting_frame = get_number_of_frames(timeline_info["start_frame"], frame_rate)
-    clip_offset_frames = get_number_of_frames(clip_offset, frame_rate)
-    chapter_start_frames = get_number_of_frames(marker_start, frame_rate)
-    clip_start_frames = get_number_of_frames(clip_start, frame_rate)
+    timeline_starting_frame = get_number_of_frames(timeline_start, frame_rate)
+    clip_offset_frame = get_number_of_frames(clip_offset, frame_rate)
+    clip_duration_frames = get_number_of_frames(clip_duration, frame_rate)
+    marker_start_frame = get_number_of_frames(marker_start, frame_rate)
+    clip_start_frame = get_number_of_frames(clip_start, frame_rate)
 
-    chapter_marker_timeline_frame = int((chapter_start_frames - clip_start_frames) + clip_offset_frames + timeline_starting_frame)
+    marker_offset_frame = int((marker_start_frame - clip_start_frame) + clip_offset_frame + timeline_starting_frame)
+    clip_end_frame = int(clip_offset_frame + clip_duration_frames)
 
-    return chapter_marker_timeline_frame
+    return marker_offset_frame, clip_offset_frame, clip_end_frame
 
-def marker_timeline_check(marker_frame, clip_start_frame, clip_end_frame):
-    if (marker_frame >= clip_start_frame) and (marker_frame <= clip_end_frame):
+def marker_timeline_check(marker_offset_frame, clip_offset_frame, clip_end_frame):
+    if (marker_offset_frame >= clip_offset_frame) and (marker_offset_frame <= clip_end_frame):
         return True
     else:
         return False
@@ -111,6 +113,7 @@ def generate_output(clips_dict, timeline_info):
 
     timeline_marker_list = []
     marker_timecode = ""
+    timeline_start_frame = timeline_info["start_frame"]
     original_frame_rate = frame_rate_to_tuple(timeline_info["frame_rate"])
     formatted_frame_rate = check_for_ndf(timeline_info, original_frame_rate)
 
@@ -119,9 +122,17 @@ def generate_output(clips_dict, timeline_info):
 
         for marker in clip_marker_list:
             marker_start = marker.get("start")
-            marker_frame = grab_marker_start_time(clip_offset, clip_start, marker_start, timeline_info, original_frame_rate)
-            marker_timecode = frames_to_timecode(marker_frame, formatted_frame_rate)
-            timeline_marker_list.append(str(marker_timecode))
+            marker_offset_frame, clip_offset_frame, clip_end_frame = grab_marker_and_clip_frames(
+                clip_offset,
+                clip_start,
+                clip_duration,
+                marker_start,
+                timeline_start_frame,
+                original_frame_rate
+                )
+            if marker_timeline_check(marker_offset_frame, clip_offset_frame, clip_end_frame):
+                marker_timecode = frames_to_timecode(marker_offset_frame, formatted_frame_rate)
+                timeline_marker_list.append(str(marker_timecode))
 
     # sort list and only keep unique values, necessary due FCPX assigning duplicate chapter-markers to asset-clips in .fcpxml files
     timeline_marker_list = sorted(set(timeline_marker_list))


### PR DESCRIPTION
Renamed "class-based-refactor" branch after discovering a bug in the way markers were handled.

More Info:
FCPX keeps a reference to each marker a clip has even if that marker is not actually visible in the timeline. This can be helpful to users editing in FCPX, but created an issue with the way I was handling marker selection. A simple fix was to take the timeline frame number of each marker and make sure that it's possible for that marker to actually exist in the timeline given the start and end timeline frames of the clip it belongs to.